### PR TITLE
l10n_fr_chorus_account: Handle companies with parents

### DIFF
--- a/l10n_fr_chorus_account/models/chorus_partner_service.py
+++ b/l10n_fr_chorus_account/models/chorus_partner_service.py
@@ -16,7 +16,7 @@ class ChorusPartnerService(models.Model):
 
     partner_id = fields.Many2one(
         'res.partner', string='Customer', ondelete='cascade',
-        domain=[('parent_id', '=', False)])
+        domain=[('is_company', '=', True)])
     code = fields.Char(string='Service Code', required=True)
     active = fields.Boolean(default=True)
     name = fields.Char(string='Service Name')

--- a/l10n_fr_chorus_account/models/partner.py
+++ b/l10n_fr_chorus_account/models/partner.py
@@ -92,7 +92,7 @@ class ResPartner(models.Model):
         raise_if_ko = self._context.get('chorus_raise_if_ko', True)
         partners = []
         for partner in self.filtered(lambda p: not p.fr_chorus_identifier):
-            if partner.parent_id:
+            if not partner.is_company:
                 if raise_if_ko:
                     raise UserError(_(
                         "Cannot get Chorus Identifier on a contact (%s)")
@@ -369,7 +369,7 @@ class ResPartner(models.Model):
     def chorus_cron(self):
         logger.info('Start Chorus partner cron')
         to_update_partners = self.search([
-            ('parent_id', '=', False),
+            ('is_company', '=', True),
             ('customer_invoice_transmit_method_code', '=', 'fr-chorus'),
             ('siren', '!=', False),
             ('nic', '!=', False)])
@@ -381,6 +381,7 @@ class ResPartner(models.Model):
         # Method used upon SO or invoice validation
         self.ensure_one()
         if (
+                not self.is_company and
                 self.parent_id and
                 self.name and
                 self.fr_chorus_service_id and


### PR DESCRIPTION
Partners that represent companies (`is_company=true`) can have parent links between themselves; this cset allows them to have their own Chorus Pro information.

Relying on `parent_id` to identify contacts is not enough as that would include these companies with parent links; instead this cset prefers checking `is_company` directly.

For inclusion into the ongoing akretion➔OCA PR over at https://github.com/OCA/l10n-france/pull/361