### PR TITLE
[FIX] l10n_fr_siret: add mail dependency for post_init_hook message_post

### DIFF
--- a/l10n_fr_siret/__manifest__.py
+++ b/l10n_fr_siret/__manifest__.py
@@ -12,7 +12,7 @@
     "maintainers": ["alexis-via"],
     "website": "https://github.com/OCA/l10n-france",
     "license": "AGPL-3",
-    "depends": ["l10n_fr"],
+    "depends": ["l10n_fr", "mail"],
     "external_dependencies": {"python": ["python-stdnum"]},
     "data": ["views/res_partner.xml"],
     "demo": ["demo/partner_demo.xml"],

--- a/l10n_fr_siret/i18n/bg.po
+++ b/l10n_fr_siret/i18n/bg.po
@@ -8,20 +8,63 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:46+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Bulgarian (https://www.transifex.com/oca/teams/23907/bg/)\n"
 "Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -30,26 +73,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -65,89 +137,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Партньор"

--- a/l10n_fr_siret/i18n/cs_CZ.po
+++ b/l10n_fr_siret/i18n/cs_CZ.po
@@ -8,21 +8,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-22 03:41+0000\n"
-"PO-Revision-Date: 2018-02-22 03:41+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:47+0000\n"
 "Last-Translator: Lukáš Spurný <lukasspurny8@gmail.com>, 2018\n"
-"Language-Team: Czech (Czech Republic) (https://www.transifex.com/oca/"
-"teams/23907/cs_CZ/)\n"
+"Language-Team: Czech (Czech Republic) (https://www.transifex.com/oca/teams/"
+"23907/cs_CZ/)\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -31,26 +74,55 @@ msgid "Companies"
 msgstr "Společnosti"
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr "Kontakt"
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
-msgstr "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
+msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -66,97 +138,103 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
-msgstr "SIRÉNA"
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-#, fuzzy
-msgid "SIRET"
-msgstr "SIRÉNA"
-
-#. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
-msgstr ""
-"Číslo NIC je oficiální číslo této kanceláře ve společnosti ve Francii. "
-"Obsahuje posledních 5 číslic čísla SIRET."
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
-msgstr ""
-"Číslo sirény je oficiální identifikační číslo společnosti ve Francii. "
-"Sestává prvních 9 číslic čísla SIRET."
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
-#, fuzzy
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
-"Číslo sirény je oficiální identifikační číslo společnosti ve Francii. "
-"Sestává prvních 9 číslic čísla SIRET."
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
+
+#~ msgid "NIC"
+#~ msgstr "NIC"
+
+#~ msgid "SIREN"
+#~ msgstr "SIRÉNA"
+
+#, fuzzy
+#~ msgid "SIRET"
+#~ msgstr "SIRÉNA"
+
+#~ msgid ""
+#~ "The NIC number is the official rank number of this office in the company "
+#~ "in France. It composes the last 5 digits of the SIRET number."
+#~ msgstr ""
+#~ "Číslo NIC je oficiální číslo této kanceláře ve společnosti ve Francii. "
+#~ "Obsahuje posledních 5 číslic čísla SIRET."
+
+#~ msgid ""
+#~ "The SIREN number is the official identity number of the company in "
+#~ "France. It composes the first 9 digits of the SIRET number."
+#~ msgstr ""
+#~ "Číslo sirény je oficiální identifikační číslo společnosti ve Francii. "
+#~ "Sestává prvních 9 číslic čísla SIRET."
+
+#, fuzzy
+#~ msgid ""
+#~ "The SIRET number is the official identity number of this company's office "
+#~ "in France. It is composed of the 9 digits of the SIREN number and the 5 "
+#~ "digits of the NIC number, ie. 14 digits."
+#~ msgstr ""
+#~ "Číslo sirény je oficiální identifikační číslo společnosti ve Francii. "
+#~ "Sestává prvních 9 číslic čísla SIRET."
 
 #~ msgid "Company Registry"
 #~ msgstr "Společnost registru"
@@ -175,7 +253,3 @@ msgstr ""
 #, python-format
 #~ msgid "The SIREN '%s' is invalid: the checksum is wrong."
 #~ msgstr "Hodnota SIREN '%s' je neplatná: kontrolní součet je nesprávný."
-
-#, python-format
-#~ msgid "The SIRET '%s%s' is invalid: the checksum is wrong."
-#~ msgstr "Hodnota SIRET '%s'%s' je neplatná: kontrolní součet je nesprávný."

--- a/l10n_fr_siret/i18n/da.po
+++ b/l10n_fr_siret/i18n/da.po
@@ -8,20 +8,63 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:47+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Danish (https://www.transifex.com/oca/teams/23907/da/)\n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -30,26 +73,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -65,89 +137,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/l10n_fr_siret/i18n/de.po
+++ b/l10n_fr_siret/i18n/de.po
@@ -8,20 +8,63 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:47+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -30,26 +73,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -65,89 +137,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/l10n_fr_siret/i18n/el_GR.po
+++ b/l10n_fr_siret/i18n/el_GR.po
@@ -8,21 +8,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:48+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Greek (Greece) (https://www.transifex.com/oca/teams/23907/"
 "el_GR/)\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -31,26 +74,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -66,89 +138,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Συνεργάτης"

--- a/l10n_fr_siret/i18n/es.po
+++ b/l10n_fr_siret/i18n/es.po
@@ -8,24 +8,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2023-10-12 11:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:49+0000\n"
 "Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
 msgstr ""
-"Marque esta casilla si el contacto es una compañía. En caso contrario, será "
-"una persona"
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
 
 #. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_company
@@ -33,27 +73,56 @@ msgid "Companies"
 msgstr "Compañías"
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr "ID de la compañía"
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr "Contacto"
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
+msgstr "Mostrar Nombre"
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
-msgstr "NIC"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
-msgstr "La matriz es una compañía"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
+msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
@@ -68,104 +137,120 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
-msgstr "SIREN"
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
-msgstr "SIRET"
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr "SIRET '%s' es inválido."
-
-#. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
-"El NIC '{nic}' del socio '{partner_name}' es incorrecto: debe tener "
-"exactamente 5 dígitos."
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
-"El número NIC es el número de rango oficial de esta oficina en la empresa en "
-"Francia. Compone los últimos 5 dígitos del número SIRET."
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
+msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
-"El SIREN '{siren}' del socio '{partner_name}' es incorrecto: debe tener "
-"exactamente 9 dígitos."
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
-"El SIREN '{siren}' del socio '{partner_name}' no es válido: la suma de "
-"comprobación es incorrecta."
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
-msgstr ""
-"El número SIREN es el número de identidad oficial de la empresa en Francia. "
-"Se compone de las 9 primeras cifras del número SIRET."
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
-"El SIRET '{siret}' del socio '{partner_name}' no es válido: la suma de "
-"comprobación es incorrecta."
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
-"El número SIRET es el número de identidad oficial de la oficina de esta "
-"empresa en Francia. Se compone de los 9 dígitos del número SIREN y los 5 "
-"dígitos del número NIC, es decir, 14 dígitos."
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
+
+#~ msgid "Check if the contact is a company, otherwise it is a person"
+#~ msgstr ""
+#~ "Marque esta casilla si el contacto es una compañía. En caso contrario, "
+#~ "será una persona"
+
+#~ msgid "NIC"
+#~ msgstr "NIC"
+
+#~ msgid "Parent is a Company"
+#~ msgstr "La matriz es una compañía"
+
+#~ msgid "SIREN"
+#~ msgstr "SIREN"
+
+#~ msgid "SIRET"
+#~ msgstr "SIRET"
+
+#~ msgid "SIRET '%s' is invalid."
+#~ msgstr "SIRET '%s' es inválido."
+
+#~ msgid ""
+#~ "The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
+#~ "exactly 5 digits."
+#~ msgstr ""
+#~ "El NIC '{nic}' del socio '{partner_name}' es incorrecto: debe tener "
+#~ "exactamente 5 dígitos."
+
+#~ msgid ""
+#~ "The NIC number is the official rank number of this office in the company "
+#~ "in France. It composes the last 5 digits of the SIRET number."
+#~ msgstr ""
+#~ "El número NIC es el número de rango oficial de esta oficina en la empresa "
+#~ "en Francia. Compone los últimos 5 dígitos del número SIRET."
+
+#~ msgid ""
+#~ "The SIREN number is the official identity number of the company in "
+#~ "France. It composes the first 9 digits of the SIRET number."
+#~ msgstr ""
+#~ "El número SIREN es el número de identidad oficial de la empresa en "
+#~ "Francia. Se compone de las 9 primeras cifras del número SIRET."
+
+#~ msgid ""
+#~ "The SIRET number is the official identity number of this company's office "
+#~ "in France. It is composed of the 9 digits of the SIREN number and the 5 "
+#~ "digits of the NIC number, ie. 14 digits."
+#~ msgstr ""
+#~ "El número SIRET es el número de identidad oficial de la oficina de esta "
+#~ "empresa en Francia. Se compone de los 9 dígitos del número SIREN y los 5 "
+#~ "dígitos del número NIC, es decir, 14 dígitos."
 
 #~ msgid "Duplicate warning: partner"
 #~ msgstr "Aviso de duplicado: socio"
@@ -176,20 +261,11 @@ msgstr ""
 #~ msgid "has the same <b>SIREN</b>."
 #~ msgstr "tiene el mismo <b>SIREN</b>."
 
-#~ msgid "Company ID"
-#~ msgstr "ID de la compañía"
-
 #~ msgid "Company Registry"
 #~ msgstr "Registro de la Compañía"
 
 #~ msgid "The name of official registry where this company was declared."
 #~ msgstr "El nombre del registro oficial donde se declaró esta empresa."
-
-#~ msgid "Display Name"
-#~ msgstr "Mostrar Nombre"
-
-#~ msgid "ID"
-#~ msgstr "ID (identificación)"
 
 #~ msgid "Last Modified on"
 #~ msgstr "Última Modificación el"
@@ -210,6 +286,3 @@ msgstr ""
 #~ msgid "The SIRET '%s%s' is invalid: the checksum is wrong."
 #~ msgstr ""
 #~ "El SIRET '%s%s' no es válido: la suma de comprobación es incorrecta."
-
-#~ msgid "Partner"
-#~ msgstr "Empresa"

--- a/l10n_fr_siret/i18n/es_MX.po
+++ b/l10n_fr_siret/i18n/es_MX.po
@@ -8,21 +8,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:49+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Spanish (Mexico) (https://www.transifex.com/oca/teams/23907/"
 "es_MX/)\n"
 "Language: es_MX\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -31,26 +74,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -66,89 +138,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Compañero"

--- a/l10n_fr_siret/i18n/fi.po
+++ b/l10n_fr_siret/i18n/fi.po
@@ -8,20 +8,63 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:05+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -30,26 +73,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -65,89 +137,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Kumppani"

--- a/l10n_fr_siret/i18n/fr.po
+++ b/l10n_fr_siret/i18n/fr.po
@@ -6,22 +6,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-31 09:55+0000\n"
-"PO-Revision-Date: 2023-06-20 16:08+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:39+0000\n"
 "Last-Translator: Alexis de Lattre <alexis@via.ecp.fr>\n"
 "Language-Team: \n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.17\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
-msgstr "Vérifier si le contact est une société, sinon c'est une personne"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
 
 #. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_company
@@ -29,27 +71,56 @@ msgid "Companies"
 msgstr "Sociétés"
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr "Contact"
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
+msgstr "ID"
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
-msgstr "NIC"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
-msgstr "Le parent est une société"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
+msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
@@ -64,96 +135,111 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
-msgstr "SIREN"
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
-msgstr "SIRET"
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr "Le SIRET '%s' est invalide."
-
-#. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
-msgstr ""
-"Le NIC est le numéro officiel de l'établissement au sein de la société en "
-"France. Il est composé des 5 derniers chiffres du SIRET."
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
+msgstr "SIREN ou SIRET"
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
-msgstr ""
-"Le SIREN est le numéro officiel de la société en France. Il est composé des "
-"9 premiers chiffres du SIRET."
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
-"Le SIRET est le numéro d'identité officiel d'un établissement d'une société "
-"en France. Il est composé des 9 chiffres du SIREN suivi des 5 chiffres du "
-"NIC, soit un total de 14 chiffres."
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
+
+#~ msgid "Check if the contact is a company, otherwise it is a person"
+#~ msgstr "Vérifier si le contact est une société, sinon c'est une personne"
+
+#~ msgid "NIC"
+#~ msgstr "NIC"
+
+#~ msgid "Parent is a Company"
+#~ msgstr "Le parent est une société"
+
+#~ msgid "SIREN"
+#~ msgstr "SIREN"
+
+#~ msgid "SIRET"
+#~ msgstr "SIRET"
+
+#~ msgid "SIRET '%s' is invalid."
+#~ msgstr "Le SIRET '%s' est invalide."
+
+#~ msgid ""
+#~ "The NIC number is the official rank number of this office in the company "
+#~ "in France. It composes the last 5 digits of the SIRET number."
+#~ msgstr ""
+#~ "Le NIC est le numéro officiel de l'établissement au sein de la société en "
+#~ "France. Il est composé des 5 derniers chiffres du SIRET."
+
+#~ msgid ""
+#~ "The SIREN number is the official identity number of the company in "
+#~ "France. It composes the first 9 digits of the SIRET number."
+#~ msgstr ""
+#~ "Le SIREN est le numéro officiel de la société en France. Il est composé "
+#~ "des 9 premiers chiffres du SIRET."
+
+#~ msgid ""
+#~ "The SIRET number is the official identity number of this company's office "
+#~ "in France. It is composed of the 9 digits of the SIREN number and the 5 "
+#~ "digits of the NIC number, ie. 14 digits."
+#~ msgstr ""
+#~ "Le SIRET est le numéro d'identité officiel d'un établissement d'une "
+#~ "société en France. Il est composé des 9 chiffres du SIREN suivi des 5 "
+#~ "chiffres du NIC, soit un total de 14 chiffres."
 
 #~ msgid "Duplicate warning: partner"
 #~ msgstr "Avertissement doublon: le partenaire"
@@ -172,12 +258,6 @@ msgstr ""
 #~ "Nom de la ville du tribunal de commerce dans laquelle la société est "
 #~ "enregistrée."
 
-#~ msgid "Display Name"
-#~ msgstr "Nom affiché"
-
-#~ msgid "ID"
-#~ msgstr "ID"
-
 #~ msgid "Last Modified on"
 #~ msgstr "Dernière modification le"
 
@@ -192,7 +272,3 @@ msgstr ""
 #, python-format
 #~ msgid "The SIREN '%s' is invalid: the checksum is wrong."
 #~ msgstr "Le SIREN '%s' est invalide : le clé de contrôle n'est pas bonne."
-
-#, python-format
-#~ msgid "The SIRET '%s%s' is invalid: the checksum is wrong."
-#~ msgstr "Le SIRET '%s%s' est invalide : la clé de contrôle n'est pas bonne."

--- a/l10n_fr_siret/i18n/fr_CH.po
+++ b/l10n_fr_siret/i18n/fr_CH.po
@@ -8,21 +8,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:50+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: French (Switzerland) (https://www.transifex.com/oca/"
-"teams/23907/fr_CH/)\n"
+"Language-Team: French (Switzerland) (https://www.transifex.com/oca/teams/"
+"23907/fr_CH/)\n"
 "Language: fr_CH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -31,26 +74,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -66,89 +138,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partenaire"

--- a/l10n_fr_siret/i18n/hr.po
+++ b/l10n_fr_siret/i18n/hr.po
@@ -8,21 +8,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:51+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -31,26 +74,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -66,89 +138,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/l10n_fr_siret/i18n/it.po
+++ b/l10n_fr_siret/i18n/it.po
@@ -8,20 +8,63 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:51+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -30,26 +73,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -65,89 +137,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/l10n_fr_siret/i18n/l10n_fr_siret.pot
+++ b/l10n_fr_siret/i18n/l10n_fr_siret.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 14:53+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,9 +16,51 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field "
+"(%(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid"
+" (%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid"
+" (%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -25,26 +69,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was"
+" a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with"
+" SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -60,86 +133,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is"
+" incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in"
-" France. It is composed of the 9 digits of the SIREN number and the 5 digits"
-" of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is"
+" wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""

--- a/l10n_fr_siret/i18n/nb_NO.po
+++ b/l10n_fr_siret/i18n/nb_NO.po
@@ -8,21 +8,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-01-24 03:43+0000\n"
-"PO-Revision-Date: 2018-01-24 03:43+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:52+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
 "Language-Team: Norwegian Bokmål (Norway) (https://www.transifex.com/oca/"
 "teams/23907/nb_NO/)\n"
 "Language: nb_NO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -31,26 +74,55 @@ msgid "Companies"
 msgstr "Firmaer"
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
-msgstr "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
+msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -66,93 +138,73 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
 
+#~ msgid "NIC"
+#~ msgstr "NIC"
+
 #~ msgid "Company Registry"
 #~ msgstr "Firmaregister"
-
-#, python-format
-#~ msgid "The SIREN '%s' is invalid: the checksum is wrong."
-#~ msgstr "SIREN-koden '%s' er ugyldig: Sjekksummen er feil."

--- a/l10n_fr_siret/i18n/nl.po
+++ b/l10n_fr_siret/i18n/nl.po
@@ -8,20 +8,63 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:52+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Dutch (https://www.transifex.com/oca/teams/23907/nl/)\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -30,26 +73,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -65,89 +137,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Relatie"

--- a/l10n_fr_siret/i18n/pt.po
+++ b/l10n_fr_siret/i18n/pt.po
@@ -8,20 +8,63 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:52+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Portuguese (https://www.transifex.com/oca/teams/23907/pt/)\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -30,26 +73,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -65,89 +137,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Parceiro"

--- a/l10n_fr_siret/i18n/pt_BR.po
+++ b/l10n_fr_siret/i18n/pt_BR.po
@@ -8,21 +8,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-17 03:38+0000\n"
-"PO-Revision-Date: 2017-01-17 03:38+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:52+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/"
-"teams/23907/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/"
+"23907/pt_BR/)\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -31,26 +74,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -66,89 +138,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Parceiro"

--- a/l10n_fr_siret/i18n/sl.po
+++ b/l10n_fr_siret/i18n/sl.po
@@ -7,22 +7,65 @@ msgid ""
 msgstr ""
 "Project-Id-Version: l10n-france (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-26 15:35+0000\n"
-"PO-Revision-Date: 2016-04-14 10:26+0000\n"
+"POT-Creation-Date: 2026-06-09 14:53+0000\n"
+"PO-Revision-Date: 2026-06-09 15:53+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: Slovenian (http://www.transifex.com/oca/OCA-l10n-france-9-0/"
 "language/sl/)\n"
 "Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
 "n%100==4 ? 2 : 3);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Check if the contact is a company, otherwise it is a person"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the SIRET field is "
+"empty."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the country is not "
+"set on that partner."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get %(field)s from partner '%(partner)s' because the partner's "
+"country is %(country)s which is not France."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get NIC from partner %(partner)s because the SIRET field (%"
+"(company_registry)s) doesn't contain a full SIRET."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIREN from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"Cannot get SIRET from partner %(partner)s because the SIRET field is invalid "
+"(%(company_registry)s)."
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -31,26 +74,55 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__company_registry
+msgid "Company ID"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
-msgid "Duplicate warning: partner(s)"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__display_name
+msgid "Display Name"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
-msgid "NIC"
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
-msgid "Parent is a Company"
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, but the 9 first digits was "
+"a valid SIREN, so the value was updated to '%(siren)s'."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/post_install.py:0
+msgid ""
+"Initial SIRET '%(company_registry)s' was invalid, so the value has been "
+"removed."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"On partner '%(partner_name)s', the VAT number %(vat)s is not consistent with "
+"SIREN %(siren)s: a french VAT number has the 9 digits of SIREN at the end."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "Partner(s)"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -66,89 +138,67 @@ msgid "Partners with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
-msgid "SIREN"
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+msgid ""
+"SIREN '%(child_siren)s' of child partner '%(child_partner)s' is different "
+"from SIREN '%(parent_siren)s' of its parent partner '%(parent_partner)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
-msgid "SIRET"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
+msgid "SIREN or SIRET"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-msgid "SIRET '%s' is invalid."
-msgstr ""
-
-#. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#: code:addons/l10n_fr_siret/post_install.py:0
 msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+"SIRET '%(company_registry)s' has been removed because it is not consistent "
+"with VAT '%(vat)s'."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+"The SIREN '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
-msgstr ""
-
-#. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+"The SIRET '%(company_registry)s' of partner '%(partner_name)s' is invalid: "
+"the checksum is wrong."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"incorrect: it must contain only digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
 msgid ""
-"The SIRET number is the official identity number of this company's office in "
-"France. It is composed of the 9 digits of the SIREN number and the 5 digits "
-"of the NIC number, ie. 14 digits."
+"The SIRET (or SIREN) '%(company_registry)s' of partner '%(partner_name)s' is "
+"wrong: it should have 14 digits (or 9 digits for SIREN)."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__company_registry
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__company_registry
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.view_partner_form
 msgid "has/have the same <b>SIREN</b>."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"


### PR DESCRIPTION
## Summary

The `post_init_hook` (`clean_bad_siren_siret`) calls `partner.message_post()`
to log invalid SIRET/SIREN corrections in the chatter.

However, `message_post` is provided by `mail.thread`, which is injected into
`res.partner` only when the `mail` module is loaded. Since `l10n_fr_siret`
only depended on `l10n_fr` → `base`, installing the module without `mail`
caused the following error: `AttributeError: 'res.partner' object has no attribute 'message_post'`

## Fix

Add `mail` to the module dependencies so `message_post` is always available
when the hook runs.

